### PR TITLE
//変更内容

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,11 +3,13 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'utils/thino_utils.dart';
+import 'screens/settings_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Hive.initFlutter();
   await Hive.openBox('notes');
+  await Hive.openBox('settings');
   runApp(const MyApp());
 }
 
@@ -58,7 +60,20 @@ class _CapturePageState extends State<CapturePage> {
   Widget build(BuildContext context) {
     final box = Hive.box('notes'); 
     return Scaffold(
-      appBar: AppBar(title: const Text('Quick Capture')),
+    appBar: AppBar(
+      title: const Text('Quick Capture'),
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.settings),
+          tooltip: '設定',
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => const SettingsScreen()),
+            );
+          },
+        ),
+      ],
+    ),
       body: Column(
         children: [
           Padding(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  final _vault = TextEditingController();
+  final _folder = TextEditingController();
+  final _datePattern = TextEditingController(text: 'yyyy-MM-dd');
+
+  late Future<void> _init;
+
+  @override
+  void initState() {
+    super.initState();
+    _init = _load(); // 初期化処理を非同期で実行
+  }
+
+  // 設定をロードするメソッド
+  // Hiveの設定ボックスから値を取得し、コントローラーにセット
+  // 初回起動時に呼び出される
+  Future<void> _load() async {
+    if (!Hive.isBoxOpen('settings')) {
+      await Hive.openBox('settings');
+    }
+    final box = Hive.box('settings');
+    _vault.text = (box.get('vault') ?? '') as String;
+    _folder.text = (box.get('folder') ?? '') as String;
+    _datePattern.text = (box.get('datePattern') ?? 'yyyy-MM-dd') as String;
+  }
+
+  // 設定を保存するメソッド
+  // コントローラーの値をHiveの設定ボックスに保存
+  Future<void> _save() async {
+    final box = Hive.box('settings');
+    await box.put('vault', _vault.text.trim());
+    await box.put('folder', _folder.text.trim());
+    await box.put('datePattern', _datePattern.text.trim());
+
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearSnackBars();
+    messenger.showSnackBar(const SnackBar(content: Text('設定を保存しました')));
+  }
+
+  @override
+  void dispose() {
+    _vault.dispose();
+    _folder.dispose();
+    _datePattern.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _init,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return  Scaffold(
+            appBar: AppBar(title: Text('設定')),
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Scaffold(
+          appBar: AppBar(title: const Text('設定')),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              const Text('Obsidian 連携', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _vault,
+                decoration: const InputDecoration(
+                  labelText: 'Vault 名（URLエンコード前）',
+                  hintText: '例: My Vault',
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _folder,
+                decoration: const InputDecoration(
+                  labelText: 'Daily フォルダ',
+                  hintText: '例: Thino/Daily',
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _datePattern,
+                decoration: const InputDecoration(
+                  labelText: '日付パターン',
+                  hintText: '例: yyyy-MM-dd',
+                ),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: _save,
+                child: const Text('保存'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
- 設定画面を新規追加（Vault名／フォルダ／日付パターンの保存・読込）
- main.dart に歯車ボタンを追加し、設定画面へ遷移可能に
- Hive で settings Box を起動時にオープン

//背景/目的
- Obsidian 連携で必要な情報をユーザーが入力できるようにするため
- 今後のファイル保存処理に備えて設定値を保持する仕組みを整備

//動作確認
- アプリ起動後、右上の歯車アイコンから設定画面に遷移できること
- 入力値を保存後、再度画面を開いたときに値が保持されていること
- flutter analyze がエラーなく通ること

//影響範囲
- lib/main.dart（AppBar 変更、settings Box の追加オープン）
- lib/screens/settings_screen.dart（新規追加）